### PR TITLE
Fixed NotImplementedError

### DIFF
--- a/heracles/handlers/getters.py
+++ b/heracles/handlers/getters.py
@@ -12,6 +12,11 @@ class GetAllDatabases(HandlerBase):
         return {'databases': GlueClient().get_all_database_names()}
 
 
+class GetDatabases(HandlerBase):
+    def execute(self, request_dict):
+        return {'databases': GlueClient().get_all_database_names()}
+
+
 class GetAllDatabaseObjects(HandlerBase):
     def execute(self, request_dict):
         databases = GlueClient().get_all_databases()


### PR DESCRIPTION
*Issue*
When Athena query is executed, following error occurred in the Lambda function, and query failed.

```
[ERROR] NotImplementedError
Traceback (most recent call last):
  File "/var/task/heracles/lambda.py", line 21, in handler
    klas = HandlerBase.get_class_for_api_name(api_name)
  File "/var/task/heracles/handlers/handlerbase.py", line 25, in get_class_for_api_name
    raise NotImplementedError
```

*Description of changes:*

Added a new class GetDatabases for GetDatabases API.
It means the same implementation is used for GetDatabases and GetAllDatabases in getters.py.