### PR TITLE
Use dockerized Lambda.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+COPY requirements.txt .
+RUN python3 -m pip install -r requirements.txt && rm requirements.txt
+
+COPY heracles ./heracles
+
+CMD [ "heracles.lambda.handler" ]

--- a/README.md
+++ b/README.md
@@ -27,9 +27,18 @@ Usage of this package requires the following:
 - IAM role for the Lambda function to access Glue
 - Cross-account execution access granted to Lambda function
 
-Follow the steps below, replacing the variables as necessary. You can also use the the [crossaccountathena.cf.yaml](crossaccountathena.cf.yaml) CloudFormation template to create the IAM role and Lambda function, but you'll need to perform the [Grant Cross-account Access to Lambda](#grant-cross-account-access-to-lambda) step manually.
+Follow the steps below, replacing the variables as necessary. You can also use one of the the CloudFormation templates [crossaccountathena.cf.yaml](crossaccountathena.cf.yaml) for the zipped Lambda or [crossaccountathena-dockerized.cf.yaml](crossaccountathena-dockerized.cf.yaml) for dockerized Lambda to create the IAM role and Lambda function, but you'll need to perform the [Grant Cross-account Access to Lambda](#grant-cross-account-access-to-lambda) step manually.
 
-For CloudFormation, download the [function2.zip](target/function2.zip) and upload it to your S3 bucket as it needs to be provided in the CloudFormation template. Then, while launching the [CFN stack](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://aws-bigdata-blog.s3.amazonaws.com/artifacts/aws-blog-cross-account-athena/cross_account_athena_stack.yaml), specify this S3 bucket, key path, source AWS account ID and Athena catalog name. It'll create the Lambda execution role, function and Athena Catalog.
+
+For CloudFormation, you can use two ways of deploying the Lambda: 
+
+#### 1. Zipped Lambda Function
+
+Download the [function2.zip](target/function2.zip) and upload it to your S3 bucket as it needs to be provided in the CloudFormation template. Then, while launching the [CFN stack](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://aws-bigdata-blog.s3.amazonaws.com/artifacts/aws-blog-cross-account-athena/cross_account_athena_stack.yaml), specify this S3 bucket, key path, source AWS account ID and Athena catalog name. It'll create the Lambda execution role, function and Athena Catalog.
+
+#### 2. Dockerized Lambda Function
+
+[Build the docker image](#user-content-docker-image) and push it to your private ECR repository (*Lambda currently doesn't support pulling images from public ECR or any other Docker registry*). Launch the CloudFormation stack and specify the image URI and the other parameters. It'll create the Lambda execution role, function and Athena Catalog.
 
 ### Create IAM Role
 
@@ -109,6 +118,10 @@ aws iam attach-role-policy --role-name $ROLE_NAME \
 
 ### Build deployment package
 
+You can either generate a zip file and upload it to S3 or build a Docker image that can be pushed to ECR.
+
+#### Zip File
+
 You must be using Python3 - I tend to use a virtualenv.
 
 ```shell
@@ -122,6 +135,16 @@ make build
 ```
 
 This creates a zip file in `target/` that can be uploaded to your Lambda function.
+
+#### Docker Image
+You must have [Docker installed](https://docs.docker.com/get-docker/).
+
+Build the Image:
+
+```shell
+docker build -t amazon-athena-cross-account-catalog.
+```
+and [push it to your ECR repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
 
 ### Create function
 

--- a/crossaccountathena-dockerized.cf.yaml
+++ b/crossaccountathena-dockerized.cf.yaml
@@ -15,12 +15,9 @@ Parameters:
     Description: Cross Account Catalog Description
     AllowedPattern: ^[a-z0-9_@-]*$
     ConstraintDescription: Must be lowercase alphabets, digits, underscore, or hyphen
-  LambdaCodeS3Bucket:
+  ImageUri:
     Type: String
-    Description: S3 bucket containing function code zip file
-  LambdaCodeS3Key:
-    Type: String
-    Description: S3 path to function zip file. Eg. prefix/functionv2.zip
+    Description: The URI to the lambda image.
   S3SpillLocation:
     Type: String
     Description: S3 path to spill Lambda response so that it doesn't exceed Lambda's limit. Eg. s3://<bucket>/<spill-prefx>/
@@ -47,11 +44,9 @@ Resources:
     Type: "AWS::Lambda::Function"
     Properties:
       Description: Allows Amazon Athena to query an AWS Glue Data Catalog in a different account
+      PackageType: Image
       Code:
-        S3Key: 
-          Ref: LambdaCodeS3Key
-        S3Bucket: 
-          Ref: LambdaCodeS3Bucket
+        ImageUri: !Ref ImageUri
       Environment:
         Variables:
           TARGET_ACCOUNT_ID:
@@ -64,10 +59,8 @@ Resources:
             Ref: S3SpillLocation
           SPILL_TTL:
             Ref: S3SpillTTL
-      Handler: heracles.lambda.handler
       Role:
         Fn::GetAtt: [ LambdaExecutionRole, Arn ]
-      Runtime: python3.7
       Timeout: 300
       MemorySize: 1024
 

--- a/crossaccountathena.cf.yaml
+++ b/crossaccountathena.cf.yaml
@@ -15,12 +15,9 @@ Parameters:
     Description: Cross Account Catalog Description
     AllowedPattern: ^[a-z0-9_@-]*$
     ConstraintDescription: Must be lowercase alphabets, digits, underscore, or hyphen
-  LambdaCodeS3Bucket:
+  ImageUri:
     Type: String
-    Description: S3 bucket containing function code zip file
-  LambdaCodeS3Key:
-    Type: String
-    Description: S3 path to function zip file. Eg. prefix/functionv2.zip
+    Description: The URI to the lambda image.
   S3SpillLocation:
     Type: String
     Description: S3 path to spill Lambda response so that it doesn't exceed Lambda's limit. Eg. s3://<bucket>/<spill-prefx>/
@@ -47,11 +44,9 @@ Resources:
     Type: "AWS::Lambda::Function"
     Properties:
       Description: Allows Amazon Athena to query an AWS Glue Data Catalog in a different account
+      PackageType: Image
       Code:
-        S3Key: 
-          Ref: LambdaCodeS3Key
-        S3Bucket: 
-          Ref: LambdaCodeS3Bucket
+        ImageUri: !Ref ImageUri
       Environment:
         Variables:
           TARGET_ACCOUNT_ID:
@@ -64,10 +59,8 @@ Resources:
             Ref: S3SpillLocation
           SPILL_TTL:
             Ref: S3SpillTTL
-      Handler: heracles.lambda.handler
       Role:
         Fn::GetAtt: [ LambdaExecutionRole, Arn ]
-      Runtime: python3.7
       Timeout: 300
       MemorySize: 1024
 


### PR DESCRIPTION
*Issue:* #6 

*Description of changes:* 
- Adds Dockerfile for creating a dockerized Lambda image
- Changes Cloudformation Template to use Image URI instead of 

In order to being able to distribute the Lambda in a better way, I created a  Dockerfile that builds the image with the 'AWS Lambda Python Runtime Interface Client'. This allows to provide the URI to the Cloudformation Template and deploy the Lambda without having to create the zip file and add it to S3. 

See the example Docker image that was automatically built with Dockerhub using my fork: https://hub.docker.com/r/carstenbo/amazon-athena-cross-account-catalog



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
